### PR TITLE
chore(infra): optimize docker usage (volume, compose boundary) ENG-36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,8 +122,8 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
-.env.*
+.env*
+!.env.example
 .venv
 env/
 venv/
@@ -161,9 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-# Data
-data
 
 .DS_Store
 

--- a/pipelines/.env.example
+++ b/pipelines/.env.example
@@ -1,5 +1,5 @@
 AIRFLOW_UID=501
-AIRFLOW_PROJ_DIR="../../pipelines"
+AIRFLOW_PROJ_DIR="."
 
 _PIP_ADDITIONAL_REQUIREMENTS="apache-airflow-providers-amazon openai"
 

--- a/pipelines/docker-compose.yml
+++ b/pipelines/docker-compose.yml
@@ -53,15 +53,15 @@ x-airflow-common: &airflow-common
   environment: &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:airflow@postgres/airflow
-    AIRFLOW__CORE__FERNET_KEY: ""
-    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: "true"
-    AIRFLOW__CORE__LOAD_EXAMPLES: "false"
-    AIRFLOW__API__AUTH_BACKENDS: "airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session"
+    AIRFLOW__CORE__FERNET_KEY: ''
+    AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
+    AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
+    AIRFLOW__API__AUTH_BACKENDS: 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
     # yamllint disable rule:line-length
     # Use simple http server on scheduler for health checks
     # See https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/logging-monitoring/check-health.html#scheduler-health-check-server
     # yamllint enable rule:line-length
-    AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: "true"
+    AIRFLOW__SCHEDULER__ENABLE_HEALTH_CHECK: 'true'
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
@@ -74,7 +74,7 @@ x-airflow-common: &airflow-common
     - ${AIRFLOW_PROJ_DIR:-.}/logs:/opt/airflow/logs
     - ${AIRFLOW_PROJ_DIR:-.}/config:/opt/airflow/config
     - ${AIRFLOW_PROJ_DIR:-.}/plugins:/opt/airflow/plugins
-  user: "${AIRFLOW_UID:-50000}:0"
+  user: '${AIRFLOW_UID:-50000}:0'
   depends_on: &airflow-common-depends-on
     postgres:
       condition: service_healthy
@@ -87,9 +87,9 @@ services:
       POSTGRES_PASSWORD: airflow
       POSTGRES_DB: airflow
     volumes:
-      - ./data:/var/lib/postgresql/data
+      - airflow-postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "airflow"]
+      test: ['CMD', 'pg_isready', '-U', 'airflow']
       interval: 10s
       retries: 5
       start_period: 5s
@@ -99,9 +99,9 @@ services:
     <<: *airflow-common
     command: webserver
     ports:
-      - "8080:8080"
+      - '8080:8080'
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8080/health"]
+      test: ['CMD', 'curl', '--fail', 'http://localhost:8080/health']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -116,7 +116,7 @@ services:
     <<: *airflow-common
     command: scheduler
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:8974/health"]
+      test: ['CMD', 'curl', '--fail', 'http://localhost:8974/health']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -131,11 +131,7 @@ services:
     <<: *airflow-common
     command: triggerer
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"',
-        ]
+      test: ['CMD-SHELL', 'airflow jobs check --job-type TriggererJob --hostname "$${HOSTNAME}"']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -201,12 +197,12 @@ services:
     # yamllint enable rule:line-length
     environment:
       <<: *airflow-common-env
-      _AIRFLOW_DB_MIGRATE: "true"
-      _AIRFLOW_WWW_USER_CREATE: "true"
+      _AIRFLOW_DB_MIGRATE: 'true'
+      _AIRFLOW_WWW_USER_CREATE: 'true'
       _AIRFLOW_WWW_USER_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME:-airflow}
       _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}
-      _PIP_ADDITIONAL_REQUIREMENTS: ""
-    user: "0:0"
+      _PIP_ADDITIONAL_REQUIREMENTS: ''
+    user: '0:0'
     volumes:
       - ${AIRFLOW_PROJ_DIR:-.}:/sources
 
@@ -216,9 +212,11 @@ services:
       - debug
     environment:
       <<: *airflow-common-env
-      CONNECTION_CHECK_MAX_COUNT: "0"
+      CONNECTION_CHECK_MAX_COUNT: '0'
     # Workaround for entrypoint issue. See: https://github.com/apache/airflow/issues/16252
     command:
       - bash
       - -c
       - airflow
+volumes:
+  airflow-postgres-data:

--- a/platform/dynamodb/dynamodb-docker-compose.yml
+++ b/platform/dynamodb/dynamodb-docker-compose.yml
@@ -1,28 +1,27 @@
-version: "3.9"
 services:
   dynamodb:
     image: amazon/dynamodb-local:latest
-    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
+    command: '-jar DynamoDBLocal.jar -sharedDb -dbPath ./data'
     healthcheck:
-      test: ["CMD-SHELL", "curl -v http://dynamodb:8000"]
+      test: ['CMD-SHELL', 'curl -v http://dynamodb:8000']
       interval: 3s
       timeout: 3s
       retries: 5
       start_period: 3s
     ports:
-      - "${DYNAMODB_PORT}:8000"
+      - '${DYNAMODB_PORT}:8000'
     volumes:
-      - "./data:/home/dynamodblocal/data"
+      - 'data:/home/dynamodblocal/data'
     restart: always
     working_dir: /home/dynamodblocal
 
   dynamodb-admin:
     image: aaronshaf/dynamodb-admin:latest
     ports:
-      - "${DYNAMODB_ADMIN_PORT}:8001"
+      - '${DYNAMODB_ADMIN_PORT}:8001'
     environment:
-      DYNAMO_ENDPOINT: "http://dynamodb:8000"
-      AWS_REGION: "eu-west-2"
+      DYNAMO_ENDPOINT: 'http://dynamodb:8000'
+      AWS_REGION: 'eu-west-2'
       AWS_ACCESS_KEY_ID: local
       AWS_SECRET_ACCESS_KEY: local
     depends_on:

--- a/platform/justfile
+++ b/platform/justfile
@@ -25,32 +25,17 @@ redis-down:
 redis-restart:
     bash run.sh redis restart
 
-# Run Airflow in Docker
-airflow-up:
-    bash run.sh airflow up
-
-# Stop Airflow
-airflow-down:
-    bash run.sh airflow down
-
-# Restart Airflow
-airflow-restart:
-    bash run.sh airflow restart
-
 # Run all services
 all-up:
     just dynamodb-up
     just redis-up
-    just airflow-up
 
 # Stop all services
 all-down:
     just dynamodb-down
     just redis-down
-    just airflow-down
 
 # Restart all services
 all-restart:
     just dynamodb-restart
     just redis-restart
-    just airflow-restart

--- a/platform/redis/redis-docker-compose.yml
+++ b/platform/redis/redis-docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   redis:
     container_name: redis-stack
@@ -7,10 +5,10 @@ services:
     environment:
       - REDIS_ARGS=--appendonly yes
     ports:
-      - "${REDIS_PORT}:6379"
-      - "${REDIS_ADMIN_PORT}:8001"
+      - '${REDIS_PORT}:6379'
+      - '${REDIS_ADMIN_PORT}:8001'
     volumes:
-      - ./data:/data
+      - data:/data
 
 volumes:
   data:

--- a/platform/run.sh
+++ b/platform/run.sh
@@ -3,11 +3,14 @@
 service=$1  # Service as the first argument
 cmd=$2      # Command as the second argument
 
+# Project names
+COMPOSE_PROJECT_NAME="platform"
+export COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME"
+
 # Service names
 ALL="all"
 DYNAMODB="dynamodb"
 REDIS="redis"
-AIRFLOW="airflow"
 RESTART_SLEEP_SEC=2
 
 usage() {
@@ -17,7 +20,6 @@ usage() {
     echo "  $ALL"
     echo "  $DYNAMODB"
     echo "  $REDIS"
-    echo "  $AIRFLOW"
     echo "Available commands:"
     echo "  up           run container"
     echo "  down         stop and remove container"
@@ -80,15 +82,6 @@ down_redis() {
     down "$REDIS" "$@"
 }
 
-# AIRFLOW
-up_airflow() {
-    up "$AIRFLOW" "$@"
-}
-
-down_airflow() {
-    down "$AIRFLOW" "$@"
-}
-
 if [[ "$1" == "-h" ]]; then
     usage
     exit 0
@@ -107,80 +100,69 @@ fi
 shift 2
 
 case $cmd in
-    up)
-        case $service in
-            "$ALL")
-                up_all "$@"
-                ;;
-            "$DYNAMODB")
-                up_dynamodb "$@"
-                ;;
-            "$REDIS")
-                up_redis "$@"
-                ;;
-            "$AIRFLOW")
-                up_airflow "$@"
-                ;;
-            *)
-                echo "Unknown service"
-                usage
-                exit 1
-                ;;
-        esac
+up)
+    case $service in
+    "$ALL")
+        up_all "$@"
         ;;
-    down)
-        case $service in
-            "$ALL")
-                down_all "$@"
-                ;;
-            "$DYNAMODB")
-                down_dynamodb "$@"
-                ;;
-            "$REDIS")
-                down_redis "$@"
-                ;;
-            "$AIRFLOW")
-                down_airflow "$@"
-                ;;
-            *)
-                echo "Unknown service"
-                usage
-                exit 1
-                ;;
-        esac
+    "$DYNAMODB")
+        up_dynamodb "$@"
         ;;
-    restart)
-        case $service in
-            "$ALL")
-                down_all "$@"
-                sleep $RESTART_SLEEP_SEC
-                up_all "$@"
-                ;;
-            "$DYNAMODB")
-                down_dynamodb "$@"
-                sleep $RESTART_SLEEP_SEC
-                up_dynamodb "$@"
-                ;;
-            "$REDIS")
-                down_redis "$@"
-                sleep $RESTART_SLEEP_SEC
-                up_redis "$@"
-                ;;
-            "$AIRFLOW")
-                down_airflow "$@"
-                sleep $RESTART_SLEEP_SEC
-                up_airflow "$@"
-                ;;
-            *)
-                echo "Unknown service"
-                usage
-                exit 1
-                ;;
-        esac
+    "$REDIS")
+        up_redis "$@"
         ;;
     *)
-        echo "Unknown command"
+        echo "Unknown service"
         usage
         exit 1
         ;;
+    esac
+    ;;
+down)
+    case $service in
+    "$ALL")
+        down_all "$@"
+        ;;
+    "$DYNAMODB")
+        down_dynamodb "$@"
+        ;;
+    "$REDIS")
+        down_redis "$@"
+        ;;
+    *)
+        echo "Unknown service"
+        usage
+        exit 1
+        ;;
+    esac
+    ;;
+restart)
+    case $service in
+    "$ALL")
+        down_all "$@"
+        sleep $RESTART_SLEEP_SEC
+        up_all "$@"
+        ;;
+    "$DYNAMODB")
+        down_dynamodb "$@"
+        sleep $RESTART_SLEEP_SEC
+        up_dynamodb "$@"
+        ;;
+    "$REDIS")
+        down_redis "$@"
+        sleep $RESTART_SLEEP_SEC
+        up_redis "$@"
+        ;;
+    *)
+        echo "Unknown service"
+        usage
+        exit 1
+        ;;
+    esac
+    ;;
+*)
+    echo "Unknown command"
+    usage
+    exit 1
+    ;;
 esac


### PR DESCRIPTION
# Pull Request

## Description and goal of this PR

I want to introduce a boundary for pipeline sub-repo, since `airflow` is not a shared infrastructure for all services, it should be only accessible by `pipelines`.

Moreover, the use of file-based volume binding has to be revised, we should only use it when we want to map config, own-created file to use inside a docker container. For data and storage related volume, it is not necessary to implement this way. It can cause some potential issue for version control because these files are relatively large and not meaningful to push to remote repo. However, for airflow configuration like `dags`, the dag we write should be bind directly to the filesystem in the container.

Name-based volume binding would make more sense in the case of postgres or redis. The volume will be controlled by Docker and we can access the volume by ssh anytime we want.

## Related Issue

- ENG-36

## Additional Information

Add any additional information or context that might be helpful for the reviewers.

## Checklist

- [x] I have tested the changes locally.
- [x] I have added appropriate documentation or comments.
- [x] I have followed the coding style guidelines.
- [x] I have updated the necessary tests.
- [x] I have reviewed the changes and ensured they are ready for merging.
