### PR TITLE
feat: add pipeline for extracting number of bed rooms ENG-40

### DIFF
--- a/scraper/scraper/items.py
+++ b/scraper/scraper/items.py
@@ -114,6 +114,9 @@ class OikotieItem(Item):
     contact_person_email = Field()
     contact_person_phone_number = Field()
 
+    # Additional fields
+    number_of_bedrooms = Field()
+
 
 class OikotieItemLoader(ItemLoader):
     default_input_processor = Identity()

--- a/scraper/scraper/pipelines.py
+++ b/scraper/scraper/pipelines.py
@@ -31,6 +31,19 @@ class DuplicateFilterPipeline:
         return item
 
 
+class ExtractNumberOfBedroomsPipeline:
+    def process_item(self, item, spider: Spider):
+        adapter = ItemAdapter(item)
+        number_of_rooms = adapter.get("number_of_rooms")
+        if number_of_rooms and number_of_rooms > 0:
+            if number_of_rooms > 1:
+                item["number_of_bedrooms"] = number_of_rooms - 1
+            else:
+                item["number_of_bedrooms"] = 1
+
+        return item
+
+
 class PutToDynamoDBPipeline:
     def __init__(self, table_name, endpoint_url):
         self.table_name = table_name

--- a/scraper/scraper/settings.py
+++ b/scraper/scraper/settings.py
@@ -82,6 +82,7 @@ ROBOTSTXT_OBEY = True
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
     "scraper.pipelines.DuplicateFilterPipeline": 100,
+    "scraper.pipelines.ExtractNumberOfBedroomsPipeline": 200,
     "scraper.pipelines.PutToDynamoDBPipeline": 500,
 }
 


### PR DESCRIPTION
# Pull Request

## Description and goal of this PR

We want to add the number of bedrooms into Oikotie model since we want the users to filter properties based on it.

The number of bedrooms, even though does not specified directly in the Oikotie web, thus we can not crawl it. However, the number of bedrooms could be extracted from the `number_of_rooms` field as follows:

- For studio apartment, `number_of_rooms` is 1 -> Number of bed rooms is 1.
- For other property types, commonly, the number of bedrooms is the `number_of_rooms` minus one (the living room).

## Related Issue

ENG-40

## Proposed Changes

List down the specific changes made in this pull request.

## Additional Information

Add any additional information or context that might be helpful for the reviewers.

## Checklist

- [x] I have tested the changes locally.
- [x] I have added appropriate documentation or comments.
- [x] I have followed the coding style guidelines.
- [x] I have updated the necessary tests.
- [x] I have reviewed the changes and ensured they are ready for merging.
