### PR TITLE
feat(infra): create infra admin role and internal developer iam user …

### DIFF
--- a/backend/infra/environments/production/.terraform.lock.hcl
+++ b/backend/infra/environments/production/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.68.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:n1X7MVAm1J+cxX4nTWTQRBx+VFQ0ma2AMJ5Ll3URlLo=",
+    "zh:045f37b115a6c94a05c6a5f2aacfe4cecbaf4b40b56917ba852d988d487e94bf",
+    "zh:0c388f1a94e7941cf7e6abcd8d958a3e325e513cb60affa3cac82e75c7bbbb73",
+    "zh:15b1f2587c06bff35a15f2d1c22eab395d549908daf05582608d729cdf54ba40",
+    "zh:16a9c0c7fa7a33aa22313d4444aeecde20831bf51f9b481a0406e3cf583378fc",
+    "zh:3330c0d49fb329dff6de17913e1a774e75aa0913106c3197814c73c3a12a4c3f",
+    "zh:40920318f774ff397c7b6a01b5e89e46eb1a55d7dc9943a310669a9357b9b501",
+    "zh:838fbac358bb72f46c8d359a28a3effb6a9d7137cdd72b9e4d2f0fcf803dc462",
+    "zh:84e694c0720bf54b3b8521bf6e05700abe4a1b3e7dd2a104efd1eb55ae5866a0",
+    "zh:90606c399498027d7d07ab78a71b574a5d8b982c4372e6b67479f7e39e153e2f",
+    "zh:9162cf25d5c0fdf672c9bbc4c3c84dd87ab6a15b4971df1f32aea6b477c0e028",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9cd8ec40a88b25e9f0f7d7f51460a921f4529554a260ffbe5083ddeba2f41ae3",
+    "zh:adeffac1d01a35bc8d2497ccceb9978b4746872143016c2c631de6cb38b6aa8d",
+    "zh:c7b682c81f9ae850669deb6239a66d8aa960abed984aad25db2d3954c09c2616",
+    "zh:d10b9f40934e14d55cfc5731d728507e50d014561322e9e0c84b33ab255a4d51",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
+  hashes = [
+    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}

--- a/backend/infra/environments/production/iam/.gitignore
+++ b/backend/infra/environments/production/iam/.gitignore
@@ -1,0 +1,1 @@
+nova_developer_credentials.txt

--- a/backend/infra/environments/production/iam/data.tf
+++ b/backend/infra/environments/production/iam/data.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+output "account_id" {
+  value = data.aws_caller_identity.current.account_id
+}

--- a/backend/infra/environments/production/iam/main.tf
+++ b/backend/infra/environments/production/iam/main.tf
@@ -1,0 +1,57 @@
+module "iam_nova_developer" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-user"
+  version = "5.44.0"
+
+  name = "nova.developer"
+
+  create_iam_access_key         = false
+  create_iam_user_login_profile = true
+  create_user                   = true
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/IAMUserChangePassword",
+    "arn:aws:iam::aws:policy/IAMSelfManageServiceSpecificCredentials",
+    "arn:aws:iam::aws:policy/IAMFullAccess"
+  ]
+
+  tags = {
+    Environment = "production"
+    Terraform   = true
+    User        = "nova.developer"
+  }
+}
+
+module "iam_infrastructure_admin_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.44.0"
+
+  role_name = "InfrastructureAdmin"
+
+  create_role = true
+  trusted_role_arns = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+    # TODO: This role should be here just temporarily until we have a proper CI/CD setup
+    module.iam_nova_developer.iam_user_arn
+  ]
+
+  custom_role_policy_arns = [
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "arn:aws:iam::aws:policy/AWSLambda_FullAccess",
+    "arn:aws:iam::aws:policy/AmazonVPCFullAccess",
+    "arn:aws:iam::aws:policy/AmazonAPIGatewayAdministrator",
+    "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess",
+    "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess",
+    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+    "arn:aws:iam::aws:policy/AmazonECS_FullAccess",
+    "arn:aws:iam::aws:policy/IAMFullAccess"
+  ]
+
+  tags = {
+    Environment = "production"
+    Terraform   = true
+    Role        = "InfrastructureAdmin"
+  }
+
+  depends_on = [module.iam_nova_developer]
+}

--- a/backend/infra/environments/production/iam/output.tf
+++ b/backend/infra/environments/production/iam/output.tf
@@ -1,0 +1,7 @@
+resource "local_file" "iam_nova_developer_user_credentials" {
+  content = templatefile("${path.module}/templates/user_credentials.tmpl", {
+    username = module.iam_nova_developer.iam_user_name
+    password = module.iam_nova_developer.iam_user_login_profile_password
+  })
+  filename = "${path.module}/nova_developer_credentials.txt"
+}

--- a/backend/infra/environments/production/iam/templates/user_credentials.tmpl
+++ b/backend/infra/environments/production/iam/templates/user_credentials.tmpl
@@ -1,0 +1,4 @@
+This file should not be shared with anyone or pushed to any repository.
+
+Username: ${username}
+Login password in AWS Console: ${password}

--- a/backend/infra/environments/production/main.tf
+++ b/backend/infra/environments/production/main.tf
@@ -1,0 +1,3 @@
+module "iam" {
+  source = "./iam"
+}


### PR DESCRIPTION
# Pull Request

## Description and goal of this PR

This PR contains changes related to IAM configuration (Terraform) for AWS account. These changes must be applied using access key/AWS configuration with access policy to change IAM (.e.g Administrator).

**New resources**:

1.  IAM Role `InfrastructureAdmin` with policies to access our necessary infra (DynamoDB, API Gateway, S3...). Additional policy could be attached later, but should follow [The principle of least privilege (PoLP) ](https://www.paloaltonetworks.com/cyberpedia/what-is-the-principle-of-least-privilege#:~:text=The%20principle%20of%20least%20privilege%20(PoLP)%20is%20an%20information%20security,to%20complete%20a%20required%20task.)
2. IAM user `nova.developer`: An IAM user temporarily to be used by human user (@nguyenfamj, @Thangphan0102) to access console and cli tools. Role `InfrastructureAdmin` can be assumed by this user to access other resources. Initially this user will not have any accesses, these should be accessed via the role.

## Related Issue

- [ENG-51](https://linear.app/nova-technologies/issue/ENG-51/[infra]-create-admin-role-for-aws-iam-and-create-iam-users-for-team)

## Checklist

- [x] I have tested the changes locally.
- [x] I have added appropriate documentation or comments.
- [x] I have followed the coding style guidelines.
- [x] I have updated the necessary tests.
- [x] I have reviewed the changes and ensured they are ready for merging.
